### PR TITLE
Browser: Resurface incognito button

### DIFF
--- a/res/layout-land/nav_screen.xml
+++ b/res/layout-land/nav_screen.xml
@@ -49,7 +49,6 @@
             style="@style/BrowserButton"
             android:gravity="center_vertical"
             android:contentDescription="@string/accessibility_button_newincognitotab"
-            android:visibility="gone"
             android:src="@drawable/ic_incognito" />
         <ImageButton
             android:id="@+id/newtab"

--- a/res/layout/nav_screen.xml
+++ b/res/layout/nav_screen.xml
@@ -41,7 +41,6 @@
             style="@style/BrowserButton"
             android:gravity="center_vertical"
             android:contentDescription="@string/accessibility_button_newincognitotab"
-            android:visibility="gone"
             android:src="@drawable/ic_incognito" />
         <ImageButton
             android:id="@+id/newtab"

--- a/res/menu/browser.xml
+++ b/res/menu/browser.xml
@@ -32,6 +32,11 @@
             android:showAsAction="never"
             android:alphabeticShortcut="n" />
         <item
+            android:id="@+id/new_incognito_tab_menu_id"
+            android:title="@string/new_incognito_tab"
+            android:icon="@drawable/ic_new_window_incognito"
+            android:showAsAction="never" />
+        <item
             android:id="@+id/bookmarks_menu_id"
             android:title="@string/bookmarks"
             android:icon="@drawable/ic_bookmarks"

--- a/src/com/android/browser/Controller.java
+++ b/src/com/android/browser/Controller.java
@@ -1617,6 +1617,10 @@ public class Controller
                 openTabToHomePage();
                 break;
 
+            case R.id.new_incognito_tab_menu_id:
+                openIncognitoTab();
+                break;
+
             case R.id.close_other_tabs_id:
                 closeOtherTabs();
                 break;

--- a/src/com/android/browser/PhoneUi.java
+++ b/src/com/android/browser/PhoneUi.java
@@ -184,10 +184,14 @@ public class PhoneUi extends BaseUi {
         if (info != null) {
             info.setVisible(false);
         }
-         MenuItem newtab = menu.findItem(R.id.new_tab_menu_id);
-        if (newtab != null && !mUseQuickControls) {
-            newtab.setVisible(false);
-         }
+        MenuItem newTab = menu.findItem(R.id.new_tab_menu_id);
+        if (newTab != null && !mUseQuickControls) {
+            newTab.setVisible(false);
+        }
+        MenuItem newIncognitoTab = menu.findItem(R.id.new_incognito_tab_menu_id);
+        if (newIncognitoTab != null && !mUseQuickControls) {
+            newIncognitoTab.setVisible(false);
+        }
         MenuItem closeOthers = menu.findItem(R.id.close_other_tabs_id);
         if (closeOthers != null) {
             boolean isLastTab = true;


### PR DESCRIPTION
The current method of entering incognito mode is too discreet, and
there is no way of knowing how to enter it (long press new tab FAB).

Resurface the incognito button in the tab navigation screen.

Furthermore, on tablets, there is no way to enter incognito mode
AFAIK (or it is ridiculously difficult to find).

On tablets, add an entry to the overflow menu for creating new
incognito tabs.

Change-Id: I1c81d2addd16c11480d978aebf07336307ec694f
